### PR TITLE
Added packaging scripts

### DIFF
--- a/scripts/7_makedeb.sh
+++ b/scripts/7_makedeb.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+source $SCRIPTDIR/env-package.sh
+
+echo
+echo "== Cleanup of ${RPIQTPKG_BUILD_DIR} =="
+echo
+rm -Rf ${RPIQTPKG_BUILD_DIR}
+mkdir -p ${RPIQTPKG_ROOT}
+
+echo
+echo "== Copying files from ${QT_INSTALL_DIR} to ${RPIQTPKG_ROOT} =="
+echo
+cp -r ${QT_INSTALL_DIR}/* ${RPIQTPKG_ROOT}
+
+echo
+echo "== Getting dependencies version =="
+echo
+sshpass -p ${RPIDEV_DEVICE_PW} scp -P ${RPIDEV_DEVICE_PORT} $SCRIPTDIR/rpiqt-deps.sh ${RPIDEV_DEVICE_USER}@${RPIDEV_DEVICE_ADDRESS}:/tmp
+DEPENDENCIES=`sshpass -p ${RPIDEV_DEVICE_PW} ssh -p ${RPIDEV_DEVICE_PORT} ${RPIDEV_DEVICE_USER}@${RPIDEV_DEVICE_ADDRESS} "chmod +x /tmp/rpiqt-deps.sh && /tmp/rpiqt-deps.sh ${RPIQTPKG_DEPENDENCIES}"`
+echo $DEPENDENCIES
+
+echo
+echo "== Creating control file =="
+echo
+mkdir -p ${RPIQTPKG_ROOT}/DEBIAN
+cat << EOF > ${RPIQTPKG_ROOT}/DEBIAN/control
+Package: ${RPIQTPKG_TITLE}
+Version: ${RPIQTPKG_VERSION}
+Section: base
+Priority: optional
+Architecture: armhf
+$DEPENDENCIES
+Maintainer: ${RPIQTPKG_MAINTAINER}
+Description: Custom build of Qt ${QT_BUILD_VERSION} for raspberry ${RPIDEV_DEVICE_VERSION}
+ When you need some sunshine, just run this
+ small program!
+EOF
+cat ${RPIQTPKG_ROOT}/DEBIAN/control
+
+echo
+echo "== Building the package =="
+echo
+dpkg-deb --build ${RPIQTPKG_ROOT}
+
+echo
+echo "== Done. =="
+echo

--- a/scripts/env-package.sh
+++ b/scripts/env-package.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+source $SCRIPTDIR/env.sh
+
+# from https://ubuntuforums.org/showthread.php?t=910717
+
+# package name, all lowercase, in the form <project>_<major version>.<minor version>-<package revision>
+export RPIQTPKG_TITLE=qt-${RPIDEV_DEVICE_VERSION}
+export RPIQTPKG_VERSION=5.9-1
+export RPIQTPKG_NAME=${RPIQTPKG_TITLE}_${RPIQTPKG_VERSION}
+
+#required raspberry pi dependecies
+#qtbase
+export RPIQTPKG_DEPENDENCIES="libboost1.55-all-dev libudev-dev libinput-dev libts-dev libmtdev-dev libjpeg-dev libfontconfig1-dev libssl-dev libdbus-1-dev libglib2.0-dev libxkbcommon-dev"
+#qtmultimedia
+export RPIQTPKG_DEPENDENCIES+=" libasound2-dev libpulse-dev gstreamer1.0-omx libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev"
+#qtwebengine
+export RPIQTPKG_DEPENDENCIES+=" libvpx-dev libsrtp0-dev libsnappy-dev libnss3-dev"
+
+# package data
+export RPIQTPKG_MAINTAINER='Your Name <you@email.com>'
+
+export RPIQTPKG_BUILD_DIR=${RPIDEV_ROOT}/package
+export RPIQTPKG_ROOT=${RPIQTPKG_BUILD_DIR}/${RPIQTPKG_NAME}

--- a/scripts/rpiqt-deps.sh
+++ b/scripts/rpiqt-deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+DEPSTRING=""
+for DEP in "$@"; do
+        VERSION=`dpkg -s $DEP | grep -i version | awk '{print $2}' | awk -F "+" '{print $1}'`
+        if [ ${#DEPSTRING} -gt 0 ]; then DEPSTRING+=", "; fi
+        DEPSTRING+=" $DEP (>= $VERSION)"
+done
+
+echo Depends: $DEPSTRING


### PR DESCRIPTION
Hi,
Instead of rsync-ing the files and having to install dependencies "by hand", here is some scripts that builds a .deb package with required dependencies and the qt build result.

There is a separate `env-package.sh` config file for package creation. The dependencies are taken from config, then versions are gathered from the device. I have taken the dependecies from the `README.MD`.

It still needs work (extract version number from qt branch), but the scripts should just work.